### PR TITLE
Upgrade WF cloud FP and datasources FP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
         <!-- Image creation properties -->
         <image.name.wildfly.runtime>quay.io/wildfly-snapshots/wildfly-runtime-jdk11-multi-arch:latest</image.name.wildfly.runtime>
         <version.wildfly>27.0.0.Alpha2-SNAPSHOT</version.wildfly>
-        <version.wildfly.cloud.galleon.pack>1.1.2.Final</version.wildfly.cloud.galleon.pack>
-        <version.wildfly.datasources.galleon.pack>2.2.0.Final</version.wildfly.datasources.galleon.pack>
+        <version.wildfly.cloud.galleon.pack>2.0.0.Alpha1</version.wildfly.cloud.galleon.pack>
+        <version.wildfly.datasources.galleon.pack>2.2.2.Final</version.wildfly.datasources.galleon.pack>
 
         <!-- Dependency versions -->
         <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>


### PR DESCRIPTION
* Up to now we were using cloud FP 1.x for WF 26.x (that is compatible with WF 27.x with some limitations), cloud FP 2.x is to be used wirh WF 27.
* datasources upgrade is to benefit from latest JDBC driver versions. This FP is fully compatible (at least for now) with WF 26 and WF 27.