### PR TITLE
Add a web-clustering test

### DIFF
--- a/images/pom.xml
+++ b/images/pom.xml
@@ -56,6 +56,7 @@
                 <module>microprofile-reactive-messaging-kafka</module>
                 <module>datasources/postgresql</module>
                 <module>elytron-oidc-client</module>
+                <module>web-clustering</module>
             </modules>
             <build>
                 <plugins>

--- a/images/web-clustering/pom.xml
+++ b/images/web-clustering/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~  Copyright 2022 Red Hat, Inc., and individual contributors
+  ~  as indicated by the @author tags.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.cloud-tests</groupId>
+        <artifactId>wildfly-cloud-test-images</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>image-cloud-server-with-web-clustering</artifactId>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <layers>
+                        <layer>cloud-server</layer>
+                        <layer>web-clustering</layer>
+                    </layers>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>image-cloud-server-with-web-clustering</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>image-microprofile-reactive-messaging-kafka</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>

--- a/tests/clustering/pom.xml
+++ b/tests/clustering/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~  Copyright 2022 Red Hat, Inc., and individual contributors
+  ~  as indicated by the @author tags.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.cloud-tests</groupId>
+        <artifactId>wildfly-cloud-tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>wildfly-cloud-tests-clustering</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>web-clustering</module>
+    </modules>
+
+</project>

--- a/tests/clustering/web-clustering/Dockerfile
+++ b/tests/clustering/web-clustering/Dockerfile
@@ -1,0 +1,1 @@
+# Needed until https://github.com/dekorateio/dekorate/issues/1000 is fixed

--- a/tests/clustering/web-clustering/pom.xml
+++ b/tests/clustering/web-clustering/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~  Copyright 2022 Red Hat, Inc., and individual contributors
+  ~  as indicated by the @author tags.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.cloud-tests</groupId>
+        <artifactId>wildfly-cloud-tests-clustering</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>wildfly-cloud-tests-web-clustering</artifactId>
+    <packaging>war</packaging>
+
+    <properties>
+        <wildfly.cloud.test.base.image.name>wildfly-cloud-test-image/image-cloud-server-with-web-clustering:latest</wildfly.cloud.test.base.image.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>image-cloud-server-with-web-clustering</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/clustering/web-clustering/src/main/java/org/wildfly/test/cloud/clustering/webclustering/MyServlet.java
+++ b/tests/clustering/web-clustering/src/main/java/org/wildfly/test/cloud/clustering/webclustering/MyServlet.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.cloud.clustering.webclustering;
+
+import static io.dekorate.kubernetes.annotation.ImagePullPolicy.Always;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import io.dekorate.kubernetes.annotation.Env;
+import io.dekorate.kubernetes.annotation.KubernetesApplication;
+import io.dekorate.kubernetes.annotation.Port;
+import io.dekorate.kubernetes.annotation.ServiceType;
+import io.dekorate.openshift.annotation.OpenshiftApplication;
+/**
+ *
+ * @author jdenise
+ */
+@KubernetesApplication(
+        envVars = {
+            @Env(name = "JGROUPS_PING_PROTOCOL", value = "dns.DNS_PING"),
+            @Env(name = "OPENSHIFT_DNS_PING_SERVICE_PORT", value = "8888"),
+            @Env(name = "OPENSHIFT_DNS_PING_SERVICE_NAME", value = "wildfly-cloud-tests-web-clustering-ping")},
+        imagePullPolicy = Always,
+        replicas = 1)
+@WebServlet(urlPatterns = {"/"})
+public class MyServlet extends HttpServlet {
+
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        long t = 0;
+        User user = (User) request.getSession().getAttribute("user");
+        if (user == null) {
+            t = System.currentTimeMillis();
+            user = new User(t);
+            request.getSession().setAttribute("user", user);
+        }
+        try ( PrintWriter out = response.getWriter()) {
+            out.println("{\n");
+            out.println("\"session\": \"" + request.getSession().getId() + "\",\n");
+            out.println("\"user\": \"" + user.getCreated() + "\"\n");
+            out.println("}\n");
+        }
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
+    /**
+     * Handles the HTTP <code>GET</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /**
+     * Handles the HTTP <code>POST</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /**
+     * Returns a short description of the servlet.
+     *
+     * @return a String containing servlet description
+     */
+    @Override
+    public String getServletInfo() {
+        return "Short description";
+    }// </editor-fold>
+
+}

--- a/tests/clustering/web-clustering/src/main/java/org/wildfly/test/cloud/clustering/webclustering/User.java
+++ b/tests/clustering/web-clustering/src/main/java/org/wildfly/test/cloud/clustering/webclustering/User.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.cloud.clustering.webclustering;
+
+import java.io.Serializable;
+
+public class User implements Serializable {
+    private final long created;
+
+    User(long created) {
+        this.created = created;
+    }
+    public long getCreated() {
+        return created;
+    }
+}

--- a/tests/clustering/web-clustering/src/main/webapp/WEB-INF/web.xml
+++ b/tests/clustering/web-clustering/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?> 
+<web-app  xmlns="http://java.sun.com/xml/ns/j2ee"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+          xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee 
+                              http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" 
+          version="2.4">
+    <distributable/>
+</web-app>

--- a/tests/clustering/web-clustering/src/test/container/ping-service.yml
+++ b/tests/clustering/web-clustering/src/test/container/ping-service.yml
@@ -1,0 +1,25 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: wildfly-cloud-tests-web-clustering-ping
+  annotations:
+    description: The JGroups ping port for clustering.
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: ping
+      protocol: TCP
+      port: 8888
+      targetPort: 8888
+  internalTrafficPolicy: Cluster
+  clusterIPs:
+    - None
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app.kubernetes.io/name: wildfly-cloud-tests-web-clustering

--- a/tests/clustering/web-clustering/src/test/java/org/wildfly/test/cloud/clustering/webclustering/WebClusteringTestCaseIT.java
+++ b/tests/clustering/web-clustering/src/test/java/org/wildfly/test/cloud/clustering/webclustering/WebClusteringTestCaseIT.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *  Copyright 2022 Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.wildfly.test.cloud.clustering.webclustering;
+
+import static org.wildfly.test.cloud.common.WildflyTags.KUBERNETES;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.wildfly.test.cloud.common.KubernetesResource;
+import org.wildfly.test.cloud.common.WildFlyCloudTestCase;
+import org.wildfly.test.cloud.common.WildFlyKubernetesIntegrationTest;
+
+import io.dekorate.testing.annotation.Inject;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+@Tag(KUBERNETES)
+@WildFlyKubernetesIntegrationTest(
+        kubernetesResources = {
+            @KubernetesResource(
+                    definitionLocation = "src/test/container/ping-service.yml"
+            ),})
+public class WebClusteringTestCaseIT extends WildFlyCloudTestCase {
+
+    @Inject
+    private KubernetesClient client;
+
+    @Test
+    public void checkWebClustering() throws Exception {
+                
+        List<Pod> lst = client.pods().withLabel("app.kubernetes.io/name", "wildfly-cloud-tests-web-clustering").list().getItems();
+        Assertions.assertEquals(1, lst.size(), "More than one pod found with expected label " + lst);
+        Pod first = lst.get(0);
+        // Get the session content from the first pod.
+        List<Map<String, String>> cookiesHolder = new ArrayList<>();
+        Map<String, String> info = getHelper().doWithWebPortForward("", url -> {
+            Response r = RestAssured.given().get(url);
+            Assertions.assertEquals(200, r.getStatusCode());
+            cookiesHolder.add(r.cookies());
+            return r.as(Map.class);
+        });
+        
+        // Scale to 2.
+        client.apps().deployments().withName("wildfly-cloud-tests-web-clustering").scale(2, true);
+        lst = client.pods().withLabel("app.kubernetes.io/name", "wildfly-cloud-tests-web-clustering").list().getItems();
+        Assertions.assertEquals(2, lst.size(), "Two pods should have been found " + lst);
+        
+        // Wait for the first pod to fully sync by watching logs for 20 seconds
+        System.out.println("[TEST] Watch logs of first pod: " + first.getMetadata().getName());
+        client.pods().withName(first.getMetadata().getName()).watchLog(System.out);
+        TimeUnit.SECONDS.sleep(20L);
+
+        // Killing the pod we interacted with. It means that session content will be retrieved from replicated content in second pod.
+        client.pods().delete(first);
+        
+         // Wait for the first pod to be deleted, safer when we kill a pod
+        System.out.println("[TEST] Watch logs of first pod: " + first.getMetadata().getName());
+        client.pods().withName(first.getMetadata().getName()).watchLog(System.out);
+        TimeUnit.SECONDS.sleep(20L);
+
+        Map<String, String> info2 = getHelper().doWithWebPortForward("", url -> {
+            Response r = RestAssured.given().cookies(cookiesHolder.get(0)).get(url);
+            Assertions.assertEquals(200, r.getStatusCode());
+            return r.as(Map.class);
+        });
+        Assertions.assertEquals(info, info2);
+    }
+
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -206,6 +206,7 @@
     <modules>
         <module>framework</module>
         <module>core</module>
+        <module>clustering</module>
         <module>datasources</module>
         <module>elytron-oidc-client</module>
         <module>manual</module>


### PR DESCRIPTION
An example that uses web-clustering to share session content between 2 pods.
Scenario is:
* 1 replica
* Access the servlet session ID and session content, store sessionID cookie
* Scale to 2
* Kill the first replica
* Access again the endpoint with the stored cookie
* Check that content is identical.