### PR TITLE
Use renamed WildFly images

### DIFF
--- a/.github/workflows/wildfly-cloud-tests.yml
+++ b/.github/workflows/wildfly-cloud-tests.yml
@@ -21,26 +21,26 @@ jobs:
     if: ${{!github.event.inputs.runtimeImage}}
     uses: ./.github/workflows/wildfly-cloud-tests-callable.yml
     with:
-      runtimeImage: quay.io/wildfly/wildfly-runtime-jdk11:latest
+      runtimeImage: quay.io/wildfly/wildfly-runtime:latest-jdk11
       type: Kubernetes
 #  openshift-jdk11:
 #    if: ${{!github.event.inputs.runtimeImage}}
 #    uses: ./.github/workflows/wildfly-cloud-tests-callable.yml
 #    with:
-#      runtimeImage: quay.io/wildfly/wildfly-runtime-jdk11:latest
+#      runtimeImage: quay.io/wildfly/wildfly-runtime:latest-jdk11
 #      type: Openshift
 
   kubernetes-jdk17:
     if: ${{!github.event.inputs.runtimeImage}}
     uses: ./.github/workflows/wildfly-cloud-tests-callable.yml
     with:
-      runtimeImage: quay.io/wildfly/wildfly-runtime-jdk17:latest
+      runtimeImage: quay.io/wildfly/wildfly-runtime:latest-jdk17
       type: Kubernetes
 #  openshift-jdk17:
 #    if: ${{!github.event.inputs.runtimeImage}}
 #    uses: ./.github/workflows/wildfly-cloud-tests-callable.yml
 #    with:
-#      runtimeImage: quay.io/wildfly/wildfly-runtime-jdk17:latest
+#      runtimeImage: quay.io/wildfly/wildfly-runtime:latest-jdk17
 #      type: Openshift
 
   # Custom image jobs

--- a/.github/workflows/wildfly-pull-request-runner.yml
+++ b/.github/workflows/wildfly-pull-request-runner.yml
@@ -9,13 +9,13 @@ jobs:
   kubernetes-jdk11:
     uses: ./.github/workflows/wildfly-cloud-tests-callable.yml
     with:
-      runtimeImage: quay.io/wildfly/wildfly-runtime-jdk11:latest
+      runtimeImage: quay.io/wildfly/wildfly-runtime:latest-jdk11
       type: Kubernetes
 
   kubernetes-jdk17:
     uses: ./.github/workflows/wildfly-cloud-tests-callable.yml
     with:
-      runtimeImage: quay.io/wildfly/wildfly-runtime-jdk17:latest
+      runtimeImage: quay.io/wildfly/wildfly-runtime:latest-jdk17
       type: Kubernetes
 
   reporter:

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ The above ensures that the image will be built before running the tests.
 The current philosophy is to have images providing a minimal amount of layers needed for the 
 tests. In other words, we will probably/generally not want to provision the full WildFly server.
 
-By default the created images are based on `quay.io/wildfly-snapshots/wildfly-runtime-jdk11:latest`.
+By default the created images are based on `quay.io/wildfly/wildfly-runtime:latest`.
 If you wish to use another image (e.g. to prevalidate a staged runtime image) you can do that by passing in
 the `image.name.wildfly.runtime` system property.
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <!-- Image creation properties -->
-        <image.name.wildfly.runtime>quay.io/wildfly-snapshots/wildfly-runtime-jdk11:latest</image.name.wildfly.runtime>
+        <image.name.wildfly.runtime>quay.io/wildfly/wildfly-runtime:latest</image.name.wildfly.runtime>
         <version.wildfly>28.0.0.Beta1-SNAPSHOT</version.wildfly>
         <version.wildfly.cloud.galleon.pack>2.0.0.Final</version.wildfly.cloud.galleon.pack>
         <version.wildfly.datasources.galleon.pack>3.0.0.Final</version.wildfly.datasources.galleon.pack>


### PR DESCRIPTION
We are renaming the wildfly-runtime images. 
This PR changes all the image names.
In addition the default image uses the latest one: wildfly-runtime:latest that is latest LTS JDK. So JDK17 (used to be JDK11).