### PR TITLE
build: Remove duplicate Maven dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,36 +198,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>kubernetes-annotations</artifactId>
-                <version>${version.io.decorate.dekorate}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>kubernetes-junit</artifactId>
-                <version>${version.io.decorate.dekorate}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>openshift-annotations</artifactId>
-                <version>${version.io.decorate.dekorate}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>openshift-junit</artifactId>
-                <version>${version.io.decorate.dekorate}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>kubernetes-client</artifactId>
                 <version>${version.io.fabric8.kubernetes}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>rest-assured</artifactId>
-                <version>${version.io.rest-assured.rest-assured}</version>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
Fixes

```
[WARNING] Some problems were encountered while building the effective model for org.wildfly.cloud-tests:wildfly-cloud-tests-common:jar:1.0-SNAPSHOT [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dekorate:kubernetes-annotations:jar -> duplicate declaration of version ${version.io.decorate.dekorate} @ org.wildfly.cloud-tests:wildfly-cloud-tests-parent:1.0-SNAPSHOT, /Users/rhusar/git/wildfly-cloud-tests/pom.xml, line 200, column 25 [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dekorate:kubernetes-junit:jar -> duplicate declaration of version ${version.io.decorate.dekorate} @ org.wildfly.cloud-tests:wildfly-cloud-tests-parent:1.0-SNAPSHOT, /Users/rhusar/git/wildfly-cloud-tests/pom.xml, line 205, column 25 [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dekorate:openshift-annotations:jar -> duplicate declaration of version ${version.io.decorate.dekorate} @ org.wildfly.cloud-tests:wildfly-cloud-tests-parent:1.0-SNAPSHOT, /Users/rhusar/git/wildfly-cloud-tests/pom.xml, line 211, column 25 [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dekorate:openshift-junit:jar -> duplicate declaration of version ${version.io.decorate.dekorate} @ org.wildfly.cloud-tests:wildfly-cloud-tests-parent:1.0-SNAPSHOT, /Users/rhusar/git/wildfly-cloud-tests/pom.xml, line 216, column 25 [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.rest-assured:rest-assured:jar -> duplicate declaration of version ${version.io.rest-assured.rest-assured} @ org.wildfly.cloud-tests:wildfly-cloud-tests-parent:1.0-SNAPSHOT, /Users/rhusar/git/wildfly-cloud-tests/pom.xml, line 232, column 25 [WARNING]
[WARNING] Some problems were encountered while building the effective model for org.wildfly.cloud-tests:wildfly-cloud-tests-parent:pom:1.0-SNAPSHOT [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dekorate:kubernetes-annotations:jar -> duplicate declaration of version ${version.io.decorate.dekorate} @ line 200, column 25 [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dekorate:kubernetes-junit:jar -> duplicate declaration of version ${version.io.decorate.dekorate} @ line 205, column 25 [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dekorate:openshift-annotations:jar -> duplicate declaration of version ${version.io.decorate.dekorate} @ line 211, column 25 [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dekorate:openshift-junit:jar -> duplicate declaration of version ${version.io.decorate.dekorate} @ line 216, column 25 [WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.rest-assured:rest-assured:jar -> duplicate declaration of version ${version.io.rest-assured.rest-assured} @ line 232, column 25 [WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build. [WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```