### PR TITLE
[WFLY-19102] Enable WebClusteringTestCaseIT for EAP

### DIFF
--- a/images/cloud-server/pom.xml
+++ b/images/cloud-server/pom.xml
@@ -34,11 +34,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
+                <groupId>${server.maven.plugin.groupId}</groupId>
+                <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                <version>${server.maven.plugin.version}</version>
                 <configuration>
                     <layers>
-                        <layer>cloud-server</layer>
+                        <layer>${cloud.feature.pack.default.config.layer}</layer>
                     </layers>
                 </configuration>
             </plugin>

--- a/images/datasources/postgresql/pom.xml
+++ b/images/datasources/postgresql/pom.xml
@@ -35,22 +35,23 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
+                <groupId>${server.maven.plugin.groupId}</groupId>
+                <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                <version>${server.maven.plugin.version}</version>
                 <configuration>
                     <feature-packs>
                         <feature-pack>
-                            <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                            <location>${server.feature.pack.gav}</location>
                         </feature-pack>
                         <feature-pack>
-                            <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+                            <location>${cloud.feature.pack.gav}</location>
                         </feature-pack>
                         <feature-pack>
-                            <location>org.wildfly:wildfly-datasources-galleon-pack:${version.wildfly.datasources.galleon.pack}</location>
+                            <location>${database.feature.pack.gav}</location>
                         </feature-pack>
                     </feature-packs>
                     <layers>
-                        <layer>cloud-server</layer>
+                        <layer>${cloud.feature.pack.default.config.layer}</layer>
                         <layer>postgresql-datasource</layer>
                     </layers>
                 </configuration>

--- a/images/elytron-oidc-client/pom.xml
+++ b/images/elytron-oidc-client/pom.xml
@@ -34,11 +34,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
+                <groupId>${server.maven.plugin.groupId}</groupId>
+                <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                <version>${server.maven.plugin.version}</version>
                 <configuration>
                     <layers>
-                        <layer>cloud-server</layer>
+                        <layer>${cloud.feature.pack.default.config.layer}</layer>
                         <layer>elytron-oidc-client</layer>
                     </layers>
                 </configuration>

--- a/images/micrometer/pom.xml
+++ b/images/micrometer/pom.xml
@@ -34,11 +34,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
+                <groupId>${server.maven.plugin.groupId}</groupId>
+                <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                <version>${server.maven.plugin.version}</version>
                 <configuration>
                     <layers>
-                        <layer>cloud-server</layer>
+                        <layer>${cloud.feature.pack.default.config.layer}</layer>
                         <layer>micrometer</layer>
                     </layers>
                     <packaging-scripts>

--- a/images/microprofile-reactive-messaging-kafka/pom.xml
+++ b/images/microprofile-reactive-messaging-kafka/pom.xml
@@ -34,11 +34,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
+                <groupId>${server.maven.plugin.groupId}</groupId>
+                <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                <version>${server.maven.plugin.version}</version>
                 <configuration>
                     <layers>
-                        <layer>cloud-server</layer>
+                        <layer>${cloud.feature.pack.default.config.layer}</layer>
                         <layer>microprofile-reactive-messaging-kafka</layer>
                     </layers>
                 </configuration>

--- a/images/opentelemetry/pom.xml
+++ b/images/opentelemetry/pom.xml
@@ -34,11 +34,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
+                <groupId>${server.maven.plugin.groupId}</groupId>
+                <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                <version>${server.maven.plugin.version}</version>
                 <configuration>
                     <layers>
-                        <layer>cloud-server</layer>
+                        <layer>${cloud.feature.pack.default.config.layer}</layer>
                         <layer>microprofile-telemetry</layer>
                         <layer>opentelemetry</layer>
                     </layers>

--- a/images/pom.xml
+++ b/images/pom.xml
@@ -34,6 +34,19 @@
     <properties>
         <!-- Here to avoid provisioning server and building images for this parent module -->
         <wildfly.cloud.test.skip.image>true</wildfly.cloud.test.skip.image>
+        <!-- WildFly defaults that can be overridden in profiles -->
+        <server.maven.plugin.groupId>org.wildfly.plugins</server.maven.plugin.groupId>
+        <server.maven.plugin.artifactId>wildfly-maven-plugin</server.maven.plugin.artifactId>
+        <server.maven.plugin.version>${version.org.wildfly.plugins.wildfly-maven-plugin}</server.maven.plugin.version>
+        <server.feature.pack.gav>org.wildfly:wildfly-galleon-pack:${version.wildfly}</server.feature.pack.gav>
+        <cloud.feature.pack.gav>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</cloud.feature.pack.gav>
+        <cloud.feature.pack.default.config.layer>cloud-server</cloud.feature.pack.default.config.layer>
+        <database.feature.pack.gav>org.wildfly:wildfly-datasources-galleon-pack:${version.wildfly.datasources.galleon.pack}</database.feature.pack.gav>
+        <!-- Channel manifest Coordinates -->
+        <channel.manifest.groupid>org.wildfly.channels</channel.manifest.groupid>
+        <channel.manifest.artifactid>wildfly</channel.manifest.artifactid>
+        <channel.manifest.version>${version.wildfly}</channel.manifest.version>
+
     </properties>
 
     <profiles>
@@ -76,17 +89,27 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <groupId>${server.maven.plugin.groupId}</groupId>
+                        <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                        <version>${server.maven.plugin.version}</version>
                         <configuration>
                             <!-- some tests check for the provisioned galleon layers -->
                             <record-provisioning-state>true</record-provisioning-state>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channel.manifest.groupid}</groupId>
+                                        <artifactId>${channel.manifest.artifactid}</artifactId>
+                                        <version>${channel.manifest.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
-                                    <location>org.wildfly:wildfly-galleon-pack:${version.wildfly}</location>
+                                    <location>${server.feature.pack.gav}</location>
                                 </feature-pack>
                                 <feature-pack>
-                                    <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.wildfly.cloud.galleon.pack}</location>
+                                    <location>${cloud.feature.pack.gav}</location>
                                 </feature-pack>
                             </feature-packs>
                             <!-- layers are set by child modules, which also need to set <skip>false</skip> -->
@@ -158,6 +181,38 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>eap</id>
+            <properties>
+                <!-- Image to use -->
+                <image.name.wildfly.runtime>registry.redhat.io/jboss-eap-8/eap8-openjdk17-runtime-openshift-rhel8:latest</image.name.wildfly.runtime>
+                <!-- Plugin coordinates -->
+                <server.maven.plugin.groupId>org.jboss.eap.plugins</server.maven.plugin.groupId>
+                <server.maven.plugin.artifactId>eap-maven-plugin</server.maven.plugin.artifactId>
+                <server.maven.plugin.version>${version.org.jboss.eap.plugins.eap-maven-plugin}</server.maven.plugin.version>
+                <!-- Other -->
+                <database.feature.pack.gav>org.jboss.eap:eap-datasources-galleon-pack:8.0.0.Final-redhat-00014</database.feature.pack.gav>
+                <!-- EAP Base properties -->
+                <server.feature.pack.gav>org.jboss.eap:wildfly-ee-galleon-pack:8.0.0.GA-redhat-00011</server.feature.pack.gav>
+                <cloud.feature.pack.gav>org.jboss.eap.cloud:eap-cloud-galleon-pack:1.0.0.Final-redhat-00008</cloud.feature.pack.gav>
+                <!-- Channel manifest Coordinates -->
+                <channel.manifest.groupid>org.jboss.eap.channels</channel.manifest.groupid>
+                <channel.manifest.artifactid>eap-8.0</channel.manifest.artifactid>
+                <channel.manifest.version>1.2.1.GA-redhat-00003</channel.manifest.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>xp</id>
+            <properties>
+                <!-- EAP Base properties -->
+                <server.feature.pack.gav>org.jboss.eap.xp:wildfly-galleon-pack:5.0.0.GA-redhat-00005</server.feature.pack.gav>
+                <cloud.feature.pack.gav>org.jboss.eap.xp.cloud:eap-xp-cloud-galleon-pack:1.0.0.Final-redhat-00006</cloud.feature.pack.gav>
+                <!-- Channel manifest Coordinates -->
+                <channel.manifest.groupid>org.jboss.eap.channels</channel.manifest.groupid>
+                <channel.manifest.artifactid>eap-xp-5.0</channel.manifest.artifactid>
+                <channel.manifest.version>1.0.0.GA-redhat-00006</channel.manifest.version>
+            </properties>
         </profile>
     </profiles>
 

--- a/images/web-clustering/pom.xml
+++ b/images/web-clustering/pom.xml
@@ -34,11 +34,12 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
+                <groupId>${server.maven.plugin.groupId}</groupId>
+                <artifactId>${server.maven.plugin.artifactId}</artifactId>
+                <version>${server.maven.plugin.version}</version>
                 <configuration>
                     <layers>
-                        <layer>cloud-server</layer>
+                        <layer>${cloud.feature.pack.default.config.layer}</layer>
                         <layer>web-clustering</layer>
                     </layers>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <version.org.apache.maven.plugins.maven-failsafe-plugin>3.5.0</version.org.apache.maven.plugins.maven-failsafe-plugin>
         <version.org.codehaus.mojo.exec-maven-plugin>3.4.1</version.org.codehaus.mojo.exec-maven-plugin>
         <version.org.wildfly.plugins.wildfly-maven-plugin>5.0.1.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.jboss.eap.plugins.eap-maven-plugin>1.0.1.Final-redhat-00008</version.org.jboss.eap.plugins.eap-maven-plugin>
 
         <!-- Kubernetes registry parameters -->
         <wildfly.cloud.test.docker.host>localhost</wildfly.cloud.test.docker.host>


### PR DESCRIPTION
Somehow I was able to make it pass.

```
mvn clean install -Dtest=WebClusteringTestCaseIT -Dwildfly.test.print.logs -Dwildfly.test.print.server-config -Dio.dekorate.log.level=DEBUG -Dmaven.test.redirectTestOutputToFile=false

...

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 73.11 s -- in org.wildfly.test.cloud.clustering.webclustering.WebClusteringTestCaseIT
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

I need MRRC enabled in my settings.xml to be able to build such image
```
    <profile>
        <id>mrrc</id>
            <repositories>
                <repository>
                        <id>redhat-ga-repository</id>
                        <url>https://maven.repository.redhat.com/ga/</url>
                    <releases>
                        <enabled>true</enabled>
                    </releases>
                    <snapshots>
                        <enabled>false</enabled>
                    </snapshots>
                </repository>
            </repositories>
            <pluginRepositories>
                <pluginRepository>
                        <id>redhat-ga-plugin-repository</id>
                        <url>https://maven.repository.redhat.com/ga/</url>
                    <releases>
                        <enabled>true</enabled>
                    </releases>
                    <snapshots>
                        <enabled>false</enabled>
                    </snapshots>
                </pluginRepository>
            </pluginRepositories>
        </profile>
```