### PR TITLE
Set Kubernetes to latest version.

### DIFF
--- a/.github/workflows/wildfly-cloud-tests-callable.yml
+++ b/.github/workflows/wildfly-cloud-tests-callable.yml
@@ -158,9 +158,9 @@ jobs:
         with:
           driver: docker
           container runtime: containerd
-          minikube version: 'v1.26.1'
+          minikube version: 'v1.33.0'
           # Downgrade K8s since 1.25 has some problems with https
-          kubernetes version: 'v1.24.3'
+          kubernetes version: 'v1.30.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: "--memory='4gb' --cpus='2'"
 


### PR DESCRIPTION
Using locally I found that sometimes the namespaces created remain in the Terminating state which causes problems when trying to rerun the job.

This caused problems trying to rerun the tests in question, since they are trying to install resources into a terminating namespace
