### PR TITLE
Try to get working on podman on Mac

### DIFF
--- a/.github/workflows/wildfly-pull-request-runner.yml
+++ b/.github/workflows/wildfly-pull-request-runner.yml
@@ -131,11 +131,16 @@ jobs:
             
             echo "CLIENT_PAYLOAD: $CLIENT_PAYLOAD"
   
+            set -x
+  
             resp=$(curl -X POST -s "https://api.github.com/repos/${TRIGGER_REPOSITORY}/dispatches" \
                 -H "Accept: application/vnd.github.v3+json" \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer ${TOKEN}" \
                 -d "{\"event_type\": \"${REPORTER_EVENT_TYPE}\", \"client_payload\": ${CLIENT_PAYLOAD} }")
+          
+            set +x
+          
             if [ -z "$resp" ]
             then
               sleep 2

--- a/README.md
+++ b/README.md
@@ -39,17 +39,25 @@ As mentioned in the [run the tests](#run-the-tests) section, we have two sets of
   minikube addons enable registry
   ````
 * In order to push to the minikube registry and expose it on localhost:5000:
-  ````shell
   # On Mac:
+  ````shell
   docker run --rm -it --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
-
-  # On Linux:
+  ````
+  On Linux:
+  ````shell
   kubectl port-forward --namespace kube-system service/registry 5000:80 &
 
-  # On Windows:
+  ````
+  On Windows:
+  ````shell
   kubectl port-forward --namespace kube-system service/registry 5000:80
   docker run --rm -it --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:host.docker.internal:5000"
   ````
+
+**NOTE:** If you are using Podman instead of Docker, you need to create a symlink from `docker` to your installed version of `podman`.
+This is because the underlying [dekorate](http://dekorate.io/) library is not aware of `podman`, and looks for an executable called `docker`.
+
+
 
   On linux you might need to add this registry as an insecure one by editing the file **/etc/containers/registries.conf** and adding the following lines:
   ````
@@ -57,6 +65,14 @@ As mentioned in the [run the tests](#run-the-tests) section, we have two sets of
   location="localhost:5000"
   insecure=true
   ````
+On Mac, you may need to do the same, but this file is not on the file system of the Podman machine. See the Podman 
+[Registries documentation](https://podman-desktop.io/docs/containers/registries#setting-up-a-registry-with-an-insecure-certificate)
+for more details. But essentially you:
+* ssh into the podman machine with `podman machine ssh --username root <optional VM name>`. 
+    * Note that GPU enabled Podman machines set up with LibKrunb don't seem to be accessible this way at the moment
+* then modify the above file as shown
+* restart the podman VM
+
   
 ##### Fedora 37+ Set Up
 


### PR DESCRIPTION
I'm seeing some strange behaviour, so this is not ready yet. I'll add to this as I go along.

I had some tests working, but then it all went strange.

Current strange things are:

When compiling each test, it just hangs here (for each test, this is not specific to micrometer)
````
[INFO] --- maven-resources-plugin:3.3.1:resources (default-resources) @ wildfly-cloud-tests-observability-micrometer ---
[INFO] skip non existing resourceDirectory /Users/kabir/sourcecontrol/wildfly/wildfly-cloud-tests/tests/observability/micrometer/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.13.0:compile (default-compile) @ wildfly-cloud-tests-observability-micrometer ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 2 source files with javac [forked debug deprecation target 11] to target/classes
````
A thread dump does proceed, but the tests don't pass in this case.

What also started happening after the above is the thing that forwards to the registry dies:


````
% docker run --rm -it --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/aarch64/APKINDEX.tar.gz
(1/4) Installing ncurses-terminfo-base (6.5_p20241006-r3)
(2/4) Installing libncursesw (6.5_p20241006-r3)
(3/4) Installing readline (8.2.13-r0)
(4/4) Installing socat (1.8.0.1-r0)
Executing busybox-1.37.0-r8.trigger
OK: 9 MiB in 19 packages
2024/12/19 15:53:58 socat[6] E connect(5, AF=2 192.168.49.2:5000, 16): Operation timed out
2024/12/19 15:53:58 socat[5] E connect(5, AF=2 192.168.49.2:5000, 16): Operation timed out
2024/12/19 15:54:11 socat[7] E connect(5, AF=2 192.168.49.2:5000, 16): Operation timed out
2024/12/19 15:54:11 socat[8] E connect(5, AF=2 192.168.49.2:5000, 16): Operation timed out
````