### PR TITLE
[292] Do not use the feature pack for the BOM and instead use the use…

### DIFF
--- a/common/junit-extension/src/main/java/org/wildfly/test/cloud/common/WildFlyKubernetesExtension.java
+++ b/common/junit-extension/src/main/java/org/wildfly/test/cloud/common/WildFlyKubernetesExtension.java
@@ -19,10 +19,11 @@
 
 package org.wildfly.test.cloud.common;
 
-import io.dekorate.testing.kubernetes.KubernetesExtension;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import static org.wildfly.test.cloud.common.WildFlyCommonExtension.WILDFLY_STORE;
+
+import io.dekorate.testing.kubernetes.KubernetesExtension;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
@@ -31,6 +32,17 @@ public class WildFlyKubernetesExtension extends KubernetesExtension {
     private static final String TEST_CONFIG = "integration-test-config";
 
     private final WildFlyCommonExtension delegate = WildFlyCommonExtension.createForKubernetes();
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+        final var result = super.evaluateExecutionCondition(context);
+        if (result.isDisabled()) {
+            // We don't want to disable a test if there is a client error. Instead, we'll allow this to continue so we
+            // can see the error in a better context.
+            return ConditionEvaluationResult.enabled("Re-enabling this run. The previous error was: " + result.getReason().orElse(null));
+        }
+        return result;
+    }
 
     @Override
     public WildFlyKubernetesIntegrationTestConfig getKubernetesIntegrationTestConfig(ExtensionContext context) {

--- a/test-bom/pom.xml
+++ b/test-bom/pom.xml
@@ -58,8 +58,8 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
-                <artifactId>wildfly-feature-pack-parent</artifactId>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-expansion-with-tools</artifactId>
                 <version>${version.wildfly}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/tests/microprofile/reactive-messaging/strimzi/src/test/java/org/wildfly/test/cloud/microprofile/reactive/messaging/strimzi/ReactiveMessagingWithStrimziIT.java
+++ b/tests/microprofile/reactive-messaging/strimzi/src/test/java/org/wildfly/test/cloud/microprofile/reactive/messaging/strimzi/ReactiveMessagingWithStrimziIT.java
@@ -27,6 +27,7 @@ import java.util.List;
 import jakarta.ws.rs.core.MediaType;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.wildfly.test.cloud.common.KubernetesResource;
@@ -53,6 +54,7 @@ import io.restassured.response.Response;
                         }),
                 @KubernetesResource(definitionLocation = "src/test/container/strimzi-topic.yml")
         })
+@Disabled("See https://github.com/wildfly-extras/wildfly-cloud-tests/issues/294")
 public class ReactiveMessagingWithStrimziIT  extends WildFlyCloudTestCase {
 
     @Test

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -111,7 +111,8 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
-            <scope>provided</scope>
+            <version>1.0.0.Final</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>


### PR DESCRIPTION
…r BOM. This is now built as part of WildFly.

The user BOM does not include Vert.x which the feature pack does. This resulted in a different version of io.vertx:vertx-core being used where the Netty dependencies were excluded. The missing Netty dependencies were causing a ClassNotFoundException to be thrown which was causing tests to be skipped.

resolves #292 