### PR TITLE
Upgrade Strimzi CRDs from v1beta2 to v1 API since Strimzi 1.0.0 dropp…

### DIFF
--- a/tests/microprofile/reactive-messaging/strimzi/src/test/container/strimzi-cluster.yml
+++ b/tests/microprofile/reactive-messaging/strimzi/src/test/container/strimzi-cluster.yml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/tests/microprofile/reactive-messaging/strimzi/src/test/container/strimzi-node-pool.yml
+++ b/tests/microprofile/reactive-messaging/strimzi/src/test/container/strimzi-node-pool.yml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: dual-role

--- a/tests/microprofile/reactive-messaging/strimzi/src/test/container/strimzi-topic.yml
+++ b/tests/microprofile/reactive-messaging/strimzi/src/test/container/strimzi-topic.yml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: strimzi


### PR DESCRIPTION
…ed support for the v1beta2 CRD API.

See https://github.com/strimzi/proposals/blob/main/113-Strimzi-v1-CRD-API-and-1.0.0-release.md